### PR TITLE
Update to .Net Core 3.1 and use C# 9.0

### DIFF
--- a/src/BuilderTestSample/BuilderTestSample.csproj
+++ b/src/BuilderTestSample/BuilderTestSample.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/BuilderTestSample/Tests/OrderServicePlaceOrder.cs
+++ b/src/BuilderTestSample/Tests/OrderServicePlaceOrder.cs
@@ -7,8 +7,8 @@ namespace BuilderTestSample.Tests
 {
     public class OrderServicePlaceOrder
     {
-        private readonly OrderService _orderService = new OrderService();
-        private readonly OrderBuilder _orderBuilder = new OrderBuilder();
+        private readonly OrderService _orderService = new ();
+        private readonly OrderBuilder _orderBuilder = new ();
 
         [Fact]
         public void ThrowsExceptionGivenOrderWithExistingId()

--- a/src/BuilderTestSample/Tests/TestBuilders/OrderBuilder.cs
+++ b/src/BuilderTestSample/Tests/TestBuilders/OrderBuilder.cs
@@ -7,7 +7,7 @@ namespace BuilderTestSample.Tests.TestBuilders
     /// </summary>
     public class OrderBuilder
     {
-        private Order _order = new Order();
+        private Order _order = new ();
 
         public OrderBuilder WithId(int id)
         {


### PR DESCRIPTION
As per stream we wanted to use new features and this makes us
type new () instead of new Order() for example